### PR TITLE
Fixed some bugs and added fusion skip option

### DIFF
--- a/all data/gui_launcher.py
+++ b/all data/gui_launcher.py
@@ -67,6 +67,7 @@ class SharedVars:
         self.GAME_MONITOR_INDEX = Value('i', 1)
         self.skip_restshop = Value('b', False)
         self.skip_ego_check = Value('b', False)
+        self.skip_ego_fusion = Value('b', False)
         self.prioritize_list_over_status = Value('b', False)
         self.debug_image_matches = Value('b', False)
         self.hard_mode = Value('b', False)
@@ -605,6 +606,7 @@ def load_gui_config():
         'x_offset': 0,
         'skip_restshop': False,
         'skip_ego_check': False,
+        'skip_ego_fusion': False,
         'y_offset': 0,
         'game_monitor': 1,
         'debug_image_matches': False,
@@ -738,6 +740,7 @@ def save_gui_config(config=None):
                 'y_offset': int(shared_vars.y_offset.value) if 'shared_vars' in globals() else 0,
                 'skip_restshop': bool(shared_vars.skip_restshop.value) if 'shared_vars' in globals() else False,
                 'skip_ego_check': bool(shared_vars.skip_ego_check.value) if 'shared_vars' in globals() else False,
+                'skip_ego_fusion': bool(shared_vars.skip_ego_fusion.value) if 'shared_vars' in globals() else False,
                 'prioritize_list_over_status': bool(shared_vars.prioritize_list_over_status.value) if 'shared_vars' in globals() else False,
                 'game_monitor': int(shared_vars.GAME_MONITOR_INDEX.value) if 'shared_vars' in globals() else 1,
                 'debug_image_matches': bool(shared_vars.debug_image_matches.value) if 'shared_vars' in globals() else False,
@@ -889,6 +892,7 @@ except Exception as e:
 try:
     shared_vars.skip_restshop.value = config['Settings'].get('skip_restshop', False)
     shared_vars.skip_ego_check.value = config['Settings'].get('skip_ego_check', False)
+    shared_vars.skip_ego_fusion.value = config['Settings'].get('skip_ego_fusion', False)
     shared_vars.prioritize_list_over_status.value = config['Settings'].get('prioritize_list_over_status', False)
     shared_vars.debug_image_matches.value = config['Settings'].get('debug_image_matches', False)
     shared_vars.hard_mode.value = config['Settings'].get('hard_mode', False)
@@ -2580,6 +2584,18 @@ def load_settings_tab():
         command=update_prioritize_list
     )
     prioritize_list_cb.pack(anchor="w", padx=10, pady=5)
+
+    skip_ego_fusion_var = ctk.BooleanVar(value=shared_vars.skip_ego_fusion.value)
+    def update_skip_ego_fusion():
+        shared_vars.skip_ego_fusion.value = skip_ego_fusion_var.get()
+        save_gui_config()
+    skip_ego_fusion_cb = ctk.CTkCheckBox(
+        automation_frame,
+        text="Skip EGO gift fusion",
+        variable=skip_ego_fusion_var,
+        command=update_skip_ego_fusion
+    )
+    skip_ego_fusion_cb.pack(anchor="w", padx=10, pady=5)
 
     # Keyboard shortcut configuration section
     ctk.CTkLabel(settings_scroll, text="Keyboard Shortcuts", font=ctk.CTkFont(size=16, weight="bold")).pack(pady=(8, 0))

--- a/all data/gui_launcher.py
+++ b/all data/gui_launcher.py
@@ -886,16 +886,16 @@ except Exception as e:
     shared_vars.GAME_MONITOR_INDEX.value = 1
     common.set_game_monitor(1)
 
-    try:
-        shared_vars.skip_restshop.value = config['Settings'].get('skip_restshop', False)
-        shared_vars.skip_ego_check.value = config['Settings'].get('skip_ego_check', False)
-        shared_vars.prioritize_list_over_status.value = config['Settings'].get('prioritize_list_over_status', False)
-        shared_vars.debug_image_matches.value = config['Settings'].get('debug_image_matches', False)
-        shared_vars.hard_mode.value = config['Settings'].get('hard_mode', False)
-        shared_vars.convert_images_to_grayscale.value = config['Settings'].get('convert_images_to_grayscale', True)
-        shared_vars.reconnection_delay.value = config['Settings'].get('reconnection_delay', 6)
-    except Exception as e:
-        error(f"Error loading automation settings: {e}")
+try:
+    shared_vars.skip_restshop.value = config['Settings'].get('skip_restshop', False)
+    shared_vars.skip_ego_check.value = config['Settings'].get('skip_ego_check', False)
+    shared_vars.prioritize_list_over_status.value = config['Settings'].get('prioritize_list_over_status', False)
+    shared_vars.debug_image_matches.value = config['Settings'].get('debug_image_matches', False)
+    shared_vars.hard_mode.value = config['Settings'].get('hard_mode', False)
+    shared_vars.convert_images_to_grayscale.value = config['Settings'].get('convert_images_to_grayscale', True)
+    shared_vars.reconnection_delay.value = config['Settings'].get('reconnection_delay', 6)
+except Exception as e:
+    error(f"Error loading automation settings: {e}")
 
 # Create log filter UI variables from config
 log_filters = {

--- a/all data/src/core.py
+++ b/all data/src/core.py
@@ -158,6 +158,8 @@ def battle():
                 # Normal winrate handling
                 common.mouse_up()
                 common.key_press("p")
+                # on slower machine, it can take a little bit for winrate to go through
+                common.sleep(0.5)
                 ego_check()
                 common.key_press("enter")
                 common.mouse_down()
@@ -222,8 +224,11 @@ def ego_check():
                     common.mouse_move_click(200,200)
                     common.sleep(1)
         common.key_press("p") #Change to Damage
+        common.sleep(0.5)
         common.key_press("p") #Deselects
+        common.sleep(0.5)
         common.key_press("p") #Back to winrate
+        common.sleep(0.5)
     return
     
 def battle_check(): #pink shoes, woppily, doomsday clock

--- a/all data/src/mirror.py
+++ b/all data/src/mirror.py
@@ -694,6 +694,10 @@ class Mirror:
                 if common.element_exist("pictures/mirror/restshop/close.png"):
                     common.click_matching("pictures/mirror/restshop/close.png")
 
+        # Check if we should fuse EGO gifts
+        if shared_vars.skip_ego_fusion:
+            return
+
         statuses = ["burn","bleed","tremor","rupture","sinking","poise","charge","slash","pierce","blunt"] #List of status to use
         statuses.remove(self.status)
         common.click_matching("pictures/mirror/restshop/fusion/fuse.png")

--- a/all data/src/mirror.py
+++ b/all data/src/mirror.py
@@ -599,13 +599,8 @@ class Mirror:
             status = mirror_utils.get_status_gift_template(i)
             
             # Use higher threshold for pierce since somehow the ++ icons on upgraded gifts were detected as pierce?!?!?
-            if i == 'pierce':
-                threshold = 0.79
-            else:
-                threshold = 0.75
-
             # Similarly, it can mistake circular part of left side fusion UI as slash icon
-            if i == 'slash':
+            if i == 'pierce' or i == 'slash':
                 threshold = 0.79
             else:
                 threshold = 0.75

--- a/all data/src/mirror.py
+++ b/all data/src/mirror.py
@@ -904,7 +904,11 @@ class Mirror:
                 if len(wordless_gifts):
                     self.upgrade(wordless_gifts,"pictures/mirror/restshop/enhance/wordless_enhance.png",shift_x,shift_y)
 
-            if common.element_exist("pictures/mirror/restshop/scroll_bar.png") and not common.element_exist("pictures/mirror/restshop/scroll_bar_up.png") and not common.element_exist("pictures/CustomAdded1080p/mirror/general/fully_scrolled.png"):
+            # TODO
+            # original if statement was
+            # if common.element_exist("pictures/mirror/restshop/scroll_bar.png") and not common.element_exist("pictures/mirror/restshop/scroll_bar_up.png") and not common.element_exist("pictures/CustomAdded1080p/mirror/general/fully_scrolled.png"):
+            # but scroll_bar_up.png was missing and crashing, no idea what it is actually supposed to be, plz add
+            if common.element_exist("pictures/mirror/restshop/scroll_bar.png") and not common.element_exist("pictures/CustomAdded1080p/mirror/general/fully_scrolled.png"):
                 common.click_matching("pictures/mirror/restshop/scroll_bar.png")
                 for k in range(5):
                     common.mouse_scroll(-1000)

--- a/all data/src/mirror.py
+++ b/all data/src/mirror.py
@@ -999,6 +999,7 @@ class Mirror:
         common.click_matching("pictures/general/beeg_confirm.png")
         common.mouse_move(200,200)
         common.click_matching("pictures/general/claim_rewards.png")
+        common.sleep(1)
         common.click_matching("pictures/general/md_claim.png")
         common.sleep(0.5)
         if common.element_exist("pictures/general/confirm_w.png"):
@@ -1023,6 +1024,7 @@ class Mirror:
         common.click_matching("pictures/general/beeg_confirm.png")
         common.mouse_move(200,200)
         common.click_matching("pictures/general/claim_rewards.png")
+        common.sleep(1)
         common.click_matching("pictures/general/give_up.png")
         common.click_matching("pictures/general/confirm_w.png")
         post_run_load()

--- a/all data/src/mirror.py
+++ b/all data/src/mirror.py
@@ -603,6 +603,12 @@ class Mirror:
                 threshold = 0.79
             else:
                 threshold = 0.75
+
+            # Similarly, it can mistake circular part of left side fusion UI as slash icon
+            if i == 'slash':
+                threshold = 0.79
+            else:
+                threshold = 0.75
             
             status_coords = common.ifexist_match(status, threshold)
             if status_coords:

--- a/all data/src/shared_vars.py
+++ b/all data/src/shared_vars.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 def _load_shared_vars():
     """Load shared variables from gui_config.json automatically"""
-    global skip_ego_check, skip_restshop, hard_mode, x_offset, y_offset
+    global skip_ego_check, skip_restshop, skip_ego_fusion, hard_mode, x_offset, y_offset
     global debug_image_matches, convert_images_to_grayscale, reconnection_delay
     global reconnect_when_internet_reachable, prioritize_list_over_status
     
@@ -32,6 +32,7 @@ def _load_shared_vars():
     default_values = {
         'skip_ego_check': False,
         'skip_restshop': False,
+        'skip_ego_fusion': False,
         'hard_mode': False,
         'x_offset': 0,
         'y_offset': 0,
@@ -84,7 +85,7 @@ _load_shared_vars()
 
 # Export all shared variables for easy access
 __all__ = [
-    'skip_ego_check', 'skip_restshop', 'hard_mode', 'x_offset', 'y_offset',
+    'skip_ego_check', 'skip_restshop', 'skip_ego_fusion', 'hard_mode', 'x_offset', 'y_offset',
     'debug_image_matches', 'convert_images_to_grayscale', 'reconnection_delay',
     'reconnect_when_internet_reachable', 'prioritize_list_over_status',
     'reload_shared_vars'


### PR DESCRIPTION
Original pull request was: #1 but there was a force push and I don't wanna go thru resolving all that so just making a new pull request after clean resync

Bugfixes:

- Settings for automation was not being loaded correctly cause of indentation issue (yay python)
- False positive during ego fusion with slash icons, increased threshold for it
- Added slight delay after pressing winrate and clearing MD before next click can happen as on slower machine, there is a bit of delay and if next click is issued too early, it can soft lock
- **TODO FOR @Kryxzort**: There was a crash during ego upgrade process due to scroll_bar_up.png missing but the code was trying to reference it. I've removed that check for now but I recommend that after you merge my changes, you add it back in along with the actual .png

New feature:

- Added option to skip ego fusion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a "Skip EGO gift fusion" checkbox in the Settings tab, allowing users to control whether EGO gift fusion is performed.

* **Bug Fixes**
  * Improved synchronization with the UI by adding short delays after certain actions, enhancing reliability on slower machines.
  * Adjusted gift enhancement logic to prevent crashes related to missing scroll bar images.

* **Chores**
  * Updated configuration handling to support the new "Skip EGO gift fusion" setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->